### PR TITLE
Add A2DG community in readme related to issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Guide de la ***Djolof Tech*** qui se consomme le plus sur internet (Food) et qui
 
 ## Communauté
 
+* [**A2DG (Africa Dotnet Developer Group)**](https://web.facebook.com/AfricaDotnetDevelopersGroup/)
 * **BeOpen IT**
 * **Community Telenet**
 * [**Daara IT**](https://daarait.com/)


### PR DESCRIPTION
Missing a tech community in Senegal : Africa Dotnet Developer Group which is a community of African developers using the Dotnet platform. We can reech them throught [Facebook](https://web.facebook.com/AfricaDotnetDevelopersGroup/) or know more about it [here](https://www.socialnetlink.org/2016/07/16/leger-djiba-africa-dotnet-developers-group-une-passerelle-entre-lecole-et-lentreprise/) related to issue #5 .